### PR TITLE
Fix README: Correct description from MIDI pulses to audio pulses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 # Pulse24Sync VST Plugin
 
-A VST3 plugin that generates precisely 24 MIDI pulses per quarter note, with real-time tempo synchronization to your DAW.
+A VST3 plugin that generates precisely 24 audio pulses per quarter note, with real-time tempo synchronization to your DAW.
 
 ## Features
 
-- **24 Pulses per Quarter Note**: Generates exactly 24 MIDI note events per quarter note
+- **24 Pulses per Quarter Note**: Generates exactly 24 audio pulses per quarter note
 - **Tempo Synchronization**: Automatically syncs to your DAW's tempo and stays in time during tempo changes
 - **Manual Mode**: Option to set a manual BPM when not syncing to host
 - **Configurable Parameters**:
   - Enable/Disable pulse generation
-  - Adjust MIDI velocity (0-127)
-  - Select MIDI channel (1-16)
+  - Adjust pulse volume (0-127)
   - Toggle host tempo synchronization
   - Manual BPM setting (60-200 BPM)
 - **Real-time Status Display**: Shows current BPM, sync status, and pulse rate
@@ -169,7 +168,7 @@ This project includes an automated release system that builds both macOS and Win
 #### What gets built automatically:
 
 - **macOS**: VST3, Audio Unit (.component), and Standalone (.app)
-- **Windows**: VST3 and Standalone (.exe)  
+- **Windows**: VST3 and Standalone (.exe)
 - **Linux**: VST3 and Standalone
 
 #### Release workflow:
@@ -196,17 +195,17 @@ If you prefer to create releases manually:
 3. **Choose sync mode**:
    - **Sync to Host**: Automatically follows your DAW's tempo
    - **Manual Mode**: Set your own BPM using the Manual BPM slider
-4. **Configure MIDI settings**:
-   - Set the MIDI velocity for the pulses (0-127)
-   - Choose the MIDI channel (1-16)
-5. **Start playback** in your DAW - the plugin will generate 24 MIDI pulses per quarter note
+4. **Configure audio settings**:
+   - Set the pulse volume (0-127)
+5. **Start playback** in your DAW - the plugin will generate 24 audio pulses per quarter note
 
 ## Technical Details
 
 - **Sample Rate**: Supports all common sample rates (44.1kHz, 48kHz, 96kHz, etc.)
 - **Buffer Size**: Works with any buffer size
 - **Tempo Range**: 60-200 BPM (manual mode)
-- **MIDI Output**: Generates MIDI note on/off events on the selected channel
+- **Audio Output**: Generates 1kHz sine wave pulses as audio output
+- **Pulse Duration**: Approximately 22ms per pulse
 - **Precision**: High-precision timing using sample-accurate calculations
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

This PR fixes the incorrect description in the README that stated the plugin generates "MIDI pulses" when it actually generates **audio pulses**.

## Changes Made

- **Main description**: Changed from "24 MIDI pulses per quarter note" to "24 audio pulses per quarter note"
- **Features section**: 
  - Updated to mention "audio pulses" instead of "MIDI note events"
  - Changed "MIDI velocity" to "pulse volume"
  - Removed MIDI channel selection (since it's audio output)
- **Usage section**: 
  - Changed "Configure MIDI settings" to "Configure audio settings"
  - Removed MIDI channel selection
  - Updated final description to mention "audio pulses"
- **Technical Details**: 
  - Changed "MIDI Output" to "Audio Output" with details about 1kHz sine wave pulses
  - Added pulse duration information (22ms)

## Technical Background

The plugin generates 1kHz sine wave audio pulses at 24 pulses per quarter note, synchronized to the DAW's tempo. This is useful for timing reference or synchronization purposes, not MIDI event generation.

## Testing

The README now accurately reflects the plugin's actual functionality based on the source code analysis.