### PR TITLE
Replace midi channel slider with pulse width

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -49,9 +49,9 @@ void Pulse24SyncAudioProcessorEditor::resized()
     velocitySlider.setBounds(bounds.removeFromTop(40));
     bounds.removeFromTop(10);
 
-    // Channel slider
-    channelLabel.setBounds(bounds.removeFromTop(20));
-    channelSlider.setBounds(bounds.removeFromTop(40));
+    // Pulse width slider
+    pulseWidthLabel.setBounds(bounds.removeFromTop(20));
+    pulseWidthSlider.setBounds(bounds.removeFromTop(40));
     bounds.removeFromTop(10);
 
     // Sync to host button
@@ -99,18 +99,18 @@ void Pulse24SyncAudioProcessorEditor::setupUI()
     velocityAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
         audioProcessor.parameters, "pulseVelocity", velocitySlider);
 
-    // Channel slider
-    addAndMakeVisible(channelLabel);
-    channelLabel.setText("MIDI Channel", juce::dontSendNotification);
-    channelLabel.setFont(juce::Font(12.0f));
-    channelLabel.setColour(juce::Label::textColourId, juce::Colours::white);
-    channelLabel.setJustificationType(juce::Justification::centred);
+    // Pulse width slider
+    addAndMakeVisible(pulseWidthLabel);
+    pulseWidthLabel.setText("Pulse Width", juce::dontSendNotification);
+    pulseWidthLabel.setFont(juce::Font(12.0f));
+    pulseWidthLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+    pulseWidthLabel.setJustificationType(juce::Justification::centred);
 
-    addAndMakeVisible(channelSlider);
-    channelSlider.setSliderStyle(juce::Slider::LinearHorizontal);
-    channelSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 60, 20);
-    channelAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
-        audioProcessor.parameters, "pulseChannel", channelSlider);
+    addAndMakeVisible(pulseWidthSlider);
+    pulseWidthSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    pulseWidthSlider.setTextBoxStyle(juce::Slider::TextBoxRight, false, 60, 20);
+    pulseWidthAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
+        audioProcessor.parameters, "pulseWidth", pulseWidthSlider);
 
     // Sync to host button
     addAndMakeVisible(syncToHostButton);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -19,14 +19,14 @@ private:
     // UI Components
     juce::ToggleButton enabledButton;
     juce::Slider velocitySlider;
-    juce::Slider channelSlider;
+    juce::Slider pulseWidthSlider;  // Replaced channelSlider with pulseWidthSlider
     juce::ToggleButton syncToHostButton;
     juce::Slider manualBPMSlider;
 
     // Labels
     juce::Label enabledLabel;
     juce::Label velocityLabel;
-    juce::Label channelLabel;
+    juce::Label pulseWidthLabel;  // Replaced channelLabel with pulseWidthLabel
     juce::Label syncToHostLabel;
     juce::Label manualBPMLabel;
     juce::Label titleLabel;
@@ -35,7 +35,7 @@ private:
     // Parameter attachments
     std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> enabledAttachment;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> velocityAttachment;
-    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> channelAttachment;
+    std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> pulseWidthAttachment;  // Replaced channelAttachment with pulseWidthAttachment
     std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> syncToHostAttachment;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> manualBPMAttachment;
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -9,7 +9,7 @@ Pulse24SyncAudioProcessor::Pulse24SyncAudioProcessor()
         {
             std::make_unique<juce::AudioParameterBool>("enabled", "Enabled", true),
             std::make_unique<juce::AudioParameterFloat>("pulseVelocity", "Pulse Velocity", 0.0f, 127.0f, 100.0f),
-            std::make_unique<juce::AudioParameterInt>("pulseChannel", "Pulse Channel", 1, 16, 1),
+            std::make_unique<juce::AudioParameterFloat>("pulseWidth", "Pulse Width", 1.0f, 50.0f, 22.0f), // 1-50ms range, default 22ms
             std::make_unique<juce::AudioParameterBool>("syncToHost", "Sync to Host", true),
             std::make_unique<juce::AudioParameterFloat>("manualBPM", "Manual BPM", 60.0f, 200.0f, 120.0f)
         })
@@ -81,7 +81,7 @@ void Pulse24SyncAudioProcessor::prepareToPlay(double sampleRate, int samplesPerB
     // Set initial parameters
     pulseGenerator.setEnabled(*parameters.getRawParameterValue("enabled"));
     pulseGenerator.setPulseVelocity(*parameters.getRawParameterValue("pulseVelocity"));
-    pulseGenerator.setPulseChannel(static_cast<int>(*parameters.getRawParameterValue("pulseChannel")));
+    pulseGenerator.setPulseWidth(*parameters.getRawParameterValue("pulseWidth"));
     pulseGenerator.setSyncToHost(*parameters.getRawParameterValue("syncToHost"));
     pulseGenerator.setManualBPM(*parameters.getRawParameterValue("manualBPM"));
 }
@@ -109,7 +109,7 @@ void Pulse24SyncAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, j
     // Update pulse generator parameters
     pulseGenerator.setEnabled(*parameters.getRawParameterValue("enabled"));
     pulseGenerator.setPulseVelocity(*parameters.getRawParameterValue("pulseVelocity"));
-    pulseGenerator.setPulseChannel(static_cast<int>(*parameters.getRawParameterValue("pulseChannel")));
+    pulseGenerator.setPulseWidth(*parameters.getRawParameterValue("pulseWidth"));
     pulseGenerator.setSyncToHost(*parameters.getRawParameterValue("syncToHost"));
     pulseGenerator.setManualBPM(*parameters.getRawParameterValue("manualBPM"));
 

--- a/Source/PulseGenerator.cpp
+++ b/Source/PulseGenerator.cpp
@@ -7,8 +7,8 @@ PulseGenerator::PulseGenerator()
 void PulseGenerator::prepare(double newSampleRate)
 {
     sampleRate = newSampleRate;
-    // Update pulse duration based on sample rate (keep it around 22ms)
-    pulseDurationSamples = static_cast<int>(sampleRate * 0.022); // 22ms pulse duration
+    // Update pulse duration based on sample rate and pulse width
+    updatePulseDuration();
     reset();
     updatePulseRate();
 }
@@ -33,7 +33,7 @@ void PulseGenerator::process(int numSamples, double currentSampleRate, juce::Aud
     if (currentSampleRate != sampleRate)
     {
         sampleRate = currentSampleRate;
-        pulseDurationSamples = static_cast<int>(sampleRate * 0.022); // Update pulse duration
+        updatePulseDuration(); // Update pulse duration based on new sample rate
         updatePulseRate();
     }
 
@@ -196,4 +196,10 @@ float PulseGenerator::generatePulseSample(int sampleIndex)
     }
 
     return sineWave * envelope * pulseVelocity * 0.1f; // Scale down to prevent clipping
+}
+
+void PulseGenerator::updatePulseDuration()
+{
+    // Convert pulse width from milliseconds to samples
+    pulseDurationSamples = static_cast<int>(sampleRate * pulseWidthMs * 0.001);
 }

--- a/Source/PulseGenerator.h
+++ b/Source/PulseGenerator.h
@@ -16,7 +16,7 @@ public:
     // Parameter setters
     void setEnabled(bool enabled) { isEnabled = enabled; }
     void setPulseVelocity(float velocity) { pulseVelocity = juce::jlimit(0.0f, 1.0f, velocity / 127.0f); } // Convert MIDI velocity to gain
-    void setPulseChannel(int channel) { pulseChannel = channel; } // Keep for compatibility but not used for audio
+    void setPulseWidth(float widthMs) { pulseWidthMs = juce::jlimit(1.0f, 50.0f, widthMs); updatePulseDuration(); } // Set pulse width in milliseconds
     void setSyncToHost(bool sync) { syncToHost = sync; }
     void setManualBPM(float bpm) { manualBPM = bpm; }
 
@@ -29,7 +29,7 @@ public:
     // Getters for UI
     bool getEnabled() const { return isEnabled; }
     float getPulseVelocity() const { return pulseVelocity * 127.0f; } // Convert back to MIDI scale for UI
-    int getPulseChannel() const { return pulseChannel; }
+    float getPulseWidth() const { return pulseWidthMs; }
     bool getSyncToHost() const { return syncToHost; }
     float getManualBPM() const { return manualBPM; }
     double getCurrentBPM() const { return syncToHost ? hostBPM : manualBPM; }
@@ -39,7 +39,7 @@ private:
     // Parameters
     bool isEnabled = true;
     float pulseVelocity = 100.0f / 127.0f; // Store as gain (0.0 to 1.0)
-    int pulseChannel = 1; // Keep for compatibility
+    float pulseWidthMs = 22.0f; // Pulse width in milliseconds
     bool syncToHost = true;
     float manualBPM = 120.0f;
 
@@ -77,4 +77,5 @@ private:
     float generatePulseSample(int sampleIndex);
     bool detectTempoChange();  // Detect if tempo has changed
     void resyncTiming();       // Resynchronize timing when tempo changes
+    void updatePulseDuration(); // Update pulse duration based on current pulse width
 };


### PR DESCRIPTION
Replaced MIDI channel slider with a pulse width slider to control pulse duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-22290870-a916-46e9-9b98-8248c018ddca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-22290870-a916-46e9-9b98-8248c018ddca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

