### PR TITLE
Fix standalone app audio output

### DIFF
--- a/Source/PulseGenerator.cpp
+++ b/Source/PulseGenerator.cpp
@@ -26,7 +26,12 @@ void PulseGenerator::reset()
 
 void PulseGenerator::process(int numSamples, double currentSampleRate, juce::AudioBuffer<float>& audioBuffer)
 {
-    if (!isEnabled || !hostIsPlaying)
+    if (!isEnabled)
+        return;
+    
+    // In standalone mode or when not syncing to host, we should always generate audio when enabled
+    // Only skip if we're syncing to host AND the host is not playing
+    if (syncToHost && !hostIsPlaying)
         return;
 
     // Update sample rate if it changed


### PR DESCRIPTION
Fixes standalone app audio output by ensuring `PulseGenerator` processes audio when no host playhead is present.

In standalone mode, the `hostIsPlaying` flag remained `false` as there was no DAW host to provide playhead information. This prevented the `PulseGenerator` from generating any audio. The fix modifies `PluginProcessor` to default to a "playing" state when no host playhead is detected, and updates `PulseGenerator` to only skip processing if `syncToHost` is enabled and the host is not playing.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c1c5742-159f-4319-86f6-369bf59babd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c1c5742-159f-4319-86f6-369bf59babd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

