### PR TITLE
Add macOS notarization to eliminate "Apple could not verify is free of malware" warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,11 @@ jobs:
   build-macos:
     runs-on: macOS
     if: true  # Enabled for macOS builds
+    env:
+      CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
+      DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -171,21 +176,21 @@ jobs:
           sign_bundle() {
               local bundle_path="$1"
               local bundle_name=$(basename "$bundle_path")
-              
+
               if [ -z "$CODE_SIGN_IDENTITY" ]; then
                   echo "  ⚠️  Skipping code signing for $bundle_name (no signing identity set)"
                   return 0
               fi
-              
+
               echo "  🔏 Code signing $bundle_name..."
-              
+
               # Sign with entitlements and hardened runtime
               codesign --force --options runtime --entitlements entitlements.plist \
                   --sign "$CODE_SIGN_IDENTITY" --timestamp "$bundle_path"
-              
+
               if [ $? -eq 0 ]; then
                   echo "  ✅ Successfully signed $bundle_name"
-                  
+
                   # Verify the signature
                   echo "  🔍 Verifying signature..."
                   codesign --verify --deep --strict "$bundle_path"
@@ -239,6 +244,92 @@ jobs:
           if [ -d "Builds/MacOSX/build/Release/Pulse24Sync.app" ]; then
               echo "  - Signing standalone application..."
               sign_bundle "Builds/MacOSX/build/Release/Pulse24Sync.app"
+          fi
+
+      - name: Notarize macOS Plugin
+        if: env.CODE_SIGN_IDENTITY != '' && env.APPLE_ID != '' && env.NOTARIZATION_PASSWORD != ''
+        run: |
+          echo "🍎 Starting notarization process..."
+
+          # Function to notarize a bundle
+          notarize_bundle() {
+              local bundle_path="$1"
+              local bundle_name=$(basename "$bundle_path")
+
+              echo "  📦 Creating zip for notarization: $bundle_name"
+
+              # Create a temporary directory for the zip
+              local temp_dir=$(mktemp -d)
+              local zip_path="$temp_dir/${bundle_name}.zip"
+
+              # Create zip file
+              cd "$(dirname "$bundle_path")"
+              zip -r "$zip_path" "$(basename "$bundle_path")"
+
+              echo "  🚀 Submitting $bundle_name for notarization..."
+
+              # Submit for notarization
+              local submission_id=$(xcrun notarytool submit "$zip_path" \
+                  --apple-id "$APPLE_ID" \
+                  --password "$NOTARIZATION_PASSWORD" \
+                  --team-id "$DEVELOPMENT_TEAM" \
+                  --wait 2>&1 | grep "id:" | cut -d' ' -f2)
+
+              if [ $? -eq 0 ] && [ ! -z "$submission_id" ]; then
+                  echo "  ✅ Notarization completed for $bundle_name (ID: $submission_id)"
+
+                  # Staple the notarization ticket
+                  echo "  📎 Stapling notarization ticket to $bundle_name..."
+                  xcrun stapler staple "$bundle_path"
+
+                  if [ $? -eq 0 ]; then
+                      echo "  ✅ Successfully stapled notarization to $bundle_name"
+
+                      # Verify notarization
+                      echo "  🔍 Verifying notarization..."
+                      xcrun stapler validate "$bundle_path"
+                      if [ $? -eq 0 ]; then
+                          echo "  ✅ Notarization verification passed for $bundle_name"
+                      else
+                          echo "  ⚠️  Notarization verification failed for $bundle_name"
+                      fi
+                  else
+                      echo "  ❌ Failed to staple notarization to $bundle_name"
+                  fi
+              else
+                  echo "  ❌ Notarization failed for $bundle_name"
+                  return 1
+              fi
+
+              # Clean up
+              rm -rf "$temp_dir"
+          }
+
+          # Check if we have the required environment variables
+          if [ -z "$APPLE_ID" ] || [ -z "$NOTARIZATION_PASSWORD" ] || [ -z "$DEVELOPMENT_TEAM" ]; then
+              echo "  ⚠️  Skipping notarization - missing required environment variables"
+              echo "  ℹ️  Set APPLE_ID, NOTARIZATION_PASSWORD, and DEVELOPMENT_TEAM to enable notarization"
+              return 0
+          fi
+
+          echo "  ✅ Notarization credentials available"
+
+          # Notarize VST3 plugin
+          if [ -d "Builds/MacOSX/build/Release/Pulse24Sync.vst3" ]; then
+              echo "  - Notarizing VST3 plugin..."
+              notarize_bundle "Builds/MacOSX/build/Release/Pulse24Sync.vst3"
+          fi
+
+          # Notarize AU component
+          if [ -d "Builds/MacOSX/build/Release/Pulse24Sync.component" ]; then
+              echo "  - Notarizing AU component..."
+              notarize_bundle "Builds/MacOSX/build/Release/Pulse24Sync.component"
+          fi
+
+          # Notarize standalone application
+          if [ -d "Builds/MacOSX/build/Release/Pulse24Sync.app" ]; then
+              echo "  - Notarizing standalone application..."
+              notarize_bundle "Builds/MacOSX/build/Release/Pulse24Sync.app"
           fi
 
       - name: Create clean distribution

--- a/NOTARIZATION_SETUP.md
+++ b/NOTARIZATION_SETUP.md
@@ -1,0 +1,139 @@
+# Notarization Setup Guide for Pulse24Sync
+
+This guide will help you set up notarization for your Pulse24Sync plugin to eliminate the "Apple could not verify is free of malware" warning.
+
+## 🎯 The Problem
+
+Your plugin is currently code-signed with a Developer ID certificate, but it's not notarized. macOS requires Developer ID applications to be notarized by Apple before they can run without triggering security warnings.
+
+## ✅ The Solution
+
+We've added notarization to the GitHub Actions workflow. You need to set up the required secrets in your GitHub repository.
+
+## 🔑 Required GitHub Secrets
+
+You need to add these secrets to your GitHub repository:
+
+1. **Go to your GitHub repository**
+2. **Click Settings** → **Secrets and variables** → **Actions**
+3. **Click "New repository secret"** for each of the following:
+
+### 1. CODE_SIGN_IDENTITY
+- **Name**: `CODE_SIGN_IDENTITY`
+- **Value**: Your full signing identity (e.g., `"Developer ID Application: Eric Dahl (5HR8E5CWR7)"`)
+
+To find your signing identity, run:
+```bash
+security find-identity -v -p codesigning
+```
+
+### 2. DEVELOPMENT_TEAM
+- **Name**: `DEVELOPMENT_TEAM`
+- **Value**: Your Apple Developer Team ID (e.g., `5HR8E5CWR7`)
+
+This is the same ID that appears in your signing identity.
+
+### 3. APPLE_ID
+- **Name**: `APPLE_ID`
+- **Value**: Your Apple ID email address (e.g., `your-email@example.com`)
+
+### 4. NOTARIZATION_PASSWORD
+- **Name**: `NOTARIZATION_PASSWORD`
+- **Value**: An app-specific password for your Apple ID
+
+## 🔐 Creating an App-Specific Password
+
+1. **Go to https://appleid.apple.com/**
+2. **Sign in** with your Apple ID
+3. **Click "Sign-in and Security"** → **"App-Specific Passwords"**
+4. **Click "Generate Password"**
+5. **Enter a name** (e.g., "Pulse24Sync Notarization")
+6. **Copy the generated password** (it will look like: `abcd-efgh-ijkl-mnop`)
+7. **Add it as the `NOTARIZATION_PASSWORD` secret**
+
+## 🚀 Testing the Setup
+
+1. **Commit and push your changes** to trigger a new workflow run
+2. **Check the workflow logs** for the "Notarize macOS Plugin" step
+3. **Look for success messages** like:
+   ```
+   ✅ Notarization completed for Pulse24Sync.component
+   ✅ Successfully stapled notarization to Pulse24Sync.component
+   ✅ Notarization verification passed for Pulse24Sync.component
+   ```
+
+## 🔍 Verification
+
+After a successful notarized build, you can verify the notarization:
+
+```bash
+# Download the notarized plugin from GitHub Actions artifacts
+# Then verify notarization:
+xcrun stapler validate Pulse24Sync.component
+```
+
+You should see: `Pulse24Sync.component: valid`
+
+## 🛠️ Troubleshooting
+
+### Problem: "Skipping notarization - missing required environment variables"
+
+**Solution**: Make sure all four secrets are set in your GitHub repository:
+- `CODE_SIGN_IDENTITY`
+- `DEVELOPMENT_TEAM`
+- `APPLE_ID`
+- `NOTARIZATION_PASSWORD`
+
+### Problem: "Notarization failed"
+
+**Solutions**:
+1. **Check your Apple ID**: Make sure it's the same one associated with your Developer account
+2. **Verify app-specific password**: Generate a new one if needed
+3. **Check team ID**: Ensure it matches your Developer account
+4. **Check certificate**: Make sure your Developer ID certificate is valid and not expired
+
+### Problem: "Failed to staple notarization"
+
+**Solution**: This usually means the notarization was successful but stapling failed. The plugin should still work, but you may need to manually staple it.
+
+## 📋 Manual Notarization (Alternative)
+
+If you prefer to notarize manually:
+
+```bash
+# Create a zip for notarization
+cd dist
+zip -r Pulse24Sync.zip Pulse24Sync.component Pulse24Sync.vst3 Pulse24Sync.app
+
+# Submit for notarization
+xcrun notarytool submit Pulse24Sync.zip \
+  --apple-id your-apple-id@example.com \
+  --password your-app-specific-password \
+  --team-id YOUR-TEAM-ID \
+  --wait
+
+# Staple the notarization (after approval)
+xcrun stapler staple Pulse24Sync.component
+xcrun stapler staple Pulse24Sync.vst3
+xcrun stapler staple Pulse24Sync.app
+```
+
+## 🎉 Expected Results
+
+After setting up notarization:
+
+- ✅ No more "Apple could not verify is free of malware" warnings
+- ✅ Plugins install and run without security prompts
+- ✅ Users can download and use your plugin without issues
+- ✅ Professional distribution-ready builds
+
+## 📞 Getting Help
+
+If you encounter issues:
+
+1. **Check workflow logs**: Look for detailed error messages in the "Notarize macOS Plugin" step
+2. **Verify Apple Developer account**: Ensure your account is active and has the right permissions
+3. **Check certificate status**: Make sure your Developer ID certificate is valid
+4. **Test locally first**: Try manual notarization to verify your credentials work
+
+Your Pulse24Sync plugin will now be fully trusted by macOS and ready for distribution!

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ When building from source, the plugin will be automatically copied to the approp
 
 This project includes an automated release system that builds both macOS and Windows versions and creates a GitHub release with all plugin formats.
 
+### Code Signing and Notarization
+
+The build system automatically code signs and notarizes macOS plugins to eliminate security warnings. For setup instructions:
+
+- **General setup**: See [MACOS_CODE_SIGNING_GUIDE.md](MACOS_CODE_SIGNING_GUIDE.md)
+- **GitHub Actions setup**: See [GITHUB_ACTIONS_CODESIGNING.md](GITHUB_ACTIONS_CODESIGNING.md)
+- **Self-hosted runners**: See [SELF_HOSTED_RUNNER_SETUP.md](SELF_HOSTED_RUNNER_SETUP.md)
+- **Notarization setup**: See [NOTARIZATION_SETUP.md](NOTARIZATION_SETUP.md)
+
 #### To create a release:
 
 1. **Make sure all changes are committed**:

--- a/SELF_HOSTED_RUNNER_SETUP.md
+++ b/SELF_HOSTED_RUNNER_SETUP.md
@@ -1,0 +1,184 @@
+# Self-Hosted Runner Notarization Setup
+
+This guide is specifically for setting up notarization when using self-hosted GitHub Actions runners.
+
+## ✅ **Good News: Secrets Work the Same**
+
+GitHub secrets are automatically available to self-hosted runners, so the notarization setup will work identically to GitHub-hosted runners.
+
+## 🔧 **Self-Hosted Runner Specific Setup**
+
+### 1. **Certificate Verification**
+
+Your self-hosted runner needs access to the Developer ID certificate. Let's verify it's available:
+
+```bash
+# Run this on your self-hosted runner machine
+security find-identity -v -p codesigning
+```
+
+You should see output like:
+```
+2) 2E67EC7BC23153A9707EDA307526D5C70780C72E "Developer ID Application: Eric Dahl (5HR8E5CWR7)"
+```
+
+### 2. **Keychain Access**
+
+The runner needs access to the keychain containing your certificate. If you're running the runner as a different user or service, you may need to:
+
+```bash
+# Check which keychain the certificate is in
+security find-certificate -c "Developer ID Application: Eric Dahl" -a
+
+# If needed, add the keychain to the search list
+security list-keychains -s login.keychain
+```
+
+### 3. **Environment Variables**
+
+The workflow will automatically use the GitHub secrets, but you can also set environment variables directly on the runner if needed:
+
+```bash
+# Set these on your runner machine (optional, secrets are preferred)
+export CODE_SIGN_IDENTITY="Developer ID Application: Eric Dahl (5HR8E5CWR7)"
+export DEVELOPMENT_TEAM="5HR8E5CWR7"
+export APPLE_ID="your-apple-id@example.com"
+export NOTARIZATION_PASSWORD="your-app-specific-password"
+```
+
+## 🚀 **Testing the Setup**
+
+### 1. **Test Certificate Access**
+
+Create a test script to verify the runner can access your certificate:
+
+```bash
+#!/bin/bash
+# test-certificate-access.sh
+
+echo "Testing certificate access..."
+
+# Check if certificate is available
+IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1)
+
+if [ -z "$IDENTITY" ]; then
+    echo "❌ No Developer ID Application certificate found"
+    exit 1
+else
+    echo "✅ Certificate found: $IDENTITY"
+fi
+
+# Test code signing
+echo "Testing code signing..."
+echo "test" > test.txt
+codesign --sign "Developer ID Application: Eric Dahl (5HR8E5CWR7)" test.txt
+
+if [ $? -eq 0 ]; then
+    echo "✅ Code signing test passed"
+    rm test.txt
+else
+    echo "❌ Code signing test failed"
+    rm test.txt
+    exit 1
+fi
+```
+
+### 2. **Test Notarization Credentials**
+
+Test if the notarization credentials work:
+
+```bash
+#!/bin/bash
+# test-notarization.sh
+
+echo "Testing notarization credentials..."
+
+# Check if required variables are set
+if [ -z "$APPLE_ID" ] || [ -z "$NOTARIZATION_PASSWORD" ] || [ -z "$DEVELOPMENT_TEAM" ]; then
+    echo "❌ Missing required environment variables"
+    echo "Set APPLE_ID, NOTARIZATION_PASSWORD, and DEVELOPMENT_TEAM"
+    exit 1
+fi
+
+echo "✅ Notarization credentials available"
+
+# Test notarytool access
+echo "Testing notarytool..."
+xcrun notarytool info --apple-id "$APPLE_ID" --password "$NOTARIZATION_PASSWORD" --team-id "$DEVELOPMENT_TEAM"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Notarization credentials work"
+else
+    echo "❌ Notarization credentials failed"
+    exit 1
+fi
+```
+
+## 🔍 **Workflow Verification**
+
+After setting up the secrets, your workflow should show:
+
+### Successful Code Signing:
+```
+🔐 Checking code signing configuration...
+  🔍 Auto-detected signing identity: Developer ID Application: Eric Dahl (5HR8E5CWR7)
+  ✅ Found entitlements.plist
+  - Signing VST3 plugin...
+  🔏 Code signing Pulse24Sync.vst3...
+  ✅ Successfully signed Pulse24Sync.vst3
+```
+
+### Successful Notarization:
+```
+🍎 Starting notarization process...
+  ✅ Notarization credentials available
+  - Notarizing AU component...
+  📦 Creating zip for notarization: Pulse24Sync.component
+  🚀 Submitting Pulse24Sync.component for notarization...
+  ✅ Notarization completed for Pulse24Sync.component (ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+  📎 Stapling notarization ticket to Pulse24Sync.component...
+  ✅ Successfully stapled notarization to Pulse24Sync.component
+  🔍 Verifying notarization...
+  ✅ Notarization verification passed for Pulse24Sync.component
+```
+
+## 🛠️ **Troubleshooting Self-Hosted Runners**
+
+### Problem: "No Developer ID Application certificate found"
+
+**Solutions:**
+1. **Check certificate installation**: Run `security find-identity -v -p codesigning`
+2. **Check keychain access**: Ensure the runner user can access the keychain
+3. **Install certificate for runner user**: If running as a service, install the certificate for that user
+
+### Problem: "Code signing failed"
+
+**Solutions:**
+1. **Check user permissions**: Ensure the runner user has access to the certificate
+2. **Check keychain unlock**: The keychain may need to be unlocked
+3. **Test manually**: Try signing a test file manually
+
+### Problem: "Notarization credentials failed"
+
+**Solutions:**
+1. **Verify secrets**: Check that all 4 secrets are set in GitHub
+2. **Test credentials**: Use the test script above
+3. **Check Apple ID**: Ensure it's the same one associated with your Developer account
+
+## 📋 **Self-Hosted Runner Best Practices**
+
+1. **Use GitHub Secrets**: Don't hardcode credentials in runner configuration
+2. **Test locally first**: Run the test scripts on your runner machine
+3. **Monitor logs**: Check runner logs for detailed error messages
+4. **Keep certificates updated**: Ensure certificates don't expire
+5. **Secure the runner**: Ensure only authorized users can access the runner
+
+## 🎯 **Quick Setup Checklist**
+
+- [ ] Developer ID certificate installed and accessible
+- [ ] GitHub secrets configured (CODE_SIGN_IDENTITY, DEVELOPMENT_TEAM, APPLE_ID, NOTARIZATION_PASSWORD)
+- [ ] Keychain accessible to runner user
+- [ ] Test scripts pass
+- [ ] Workflow runs successfully with notarization
+
+Your self-hosted runner will now produce fully notarized plugins that macOS trusts without security warnings!

--- a/get-signing-info.sh
+++ b/get-signing-info.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Pulse24Sync - Get Signing Information
+# This script helps you get the information needed for GitHub secrets
+
+echo "========================================"
+echo "Pulse24Sync - Signing Information Helper"
+echo "========================================"
+echo ""
+
+echo "🔍 Looking for available code signing certificates..."
+echo ""
+
+# Find Developer ID Application certificates
+IDENTITIES=$(security find-identity -v -p codesigning | grep "Developer ID Application")
+
+if [ -z "$IDENTITIES" ]; then
+    echo "❌ No Developer ID Application certificates found"
+    echo ""
+    echo "To fix this:"
+    echo "1. Make sure you're enrolled in the Apple Developer Program"
+    echo "2. Download and install your Developer ID Application certificate"
+    echo "3. Run this script again"
+    exit 1
+fi
+
+echo "✅ Found Developer ID Application certificates:"
+echo ""
+
+# Display all found certificates
+echo "$IDENTITIES" | while IFS= read -r line; do
+    echo "  $line"
+done
+
+echo ""
+echo "========================================"
+echo "GitHub Secrets Setup"
+echo "========================================"
+echo ""
+
+# Extract the first (or most relevant) certificate
+FIRST_IDENTITY=$(echo "$IDENTITIES" | head -1)
+
+if [ ! -z "$FIRST_IDENTITY" ]; then
+    # Extract the identity name
+    IDENTITY_NAME=$(echo "$FIRST_IDENTITY" | sed -n 's/.*"\(.*\)"/\1/p')
+
+    # Extract the team ID (the part in parentheses)
+    TEAM_ID=$(echo "$IDENTITY_NAME" | sed -n 's/.*(\([^)]*\))/\1/p')
+
+    echo "📋 Use these values for your GitHub repository secrets:"
+    echo ""
+    echo "1. CODE_SIGN_IDENTITY:"
+    echo "   $IDENTITY_NAME"
+    echo ""
+    echo "2. DEVELOPMENT_TEAM:"
+    echo "   $TEAM_ID"
+    echo ""
+    echo "3. APPLE_ID:"
+    echo "   [Your Apple ID email address]"
+    echo ""
+    echo "4. NOTARIZATION_PASSWORD:"
+    echo "   [App-specific password from https://appleid.apple.com/]"
+    echo ""
+    echo "========================================"
+    echo "Setup Instructions:"
+    echo "========================================"
+    echo ""
+    echo "1. Go to your GitHub repository"
+    echo "2. Click Settings → Secrets and variables → Actions"
+    echo "3. Click 'New repository secret' for each of the above"
+    echo "4. Copy and paste the values exactly as shown"
+    echo ""
+    echo "For the app-specific password:"
+    echo "1. Go to https://appleid.apple.com/"
+    echo "2. Sign in with your Apple ID"
+    echo "3. Click 'Sign-in and Security' → 'App-Specific Passwords'"
+    echo "4. Click 'Generate Password'"
+    echo "5. Name it 'Pulse24Sync Notarization'"
+    echo "6. Copy the generated password"
+    echo ""
+    echo "After setting up the secrets, push your changes to trigger a new build!"
+else
+    echo "❌ Could not extract certificate information"
+    echo "Please check your certificate installation"
+fi
+
+echo ""
+echo "========================================"
+echo "Verification"
+echo "========================================"
+echo ""
+echo "After setting up the secrets, you can verify the setup by:"
+echo "1. Pushing changes to trigger a new GitHub Actions build"
+echo "2. Checking the workflow logs for the 'Notarize macOS Plugin' step"
+echo "3. Looking for success messages like '✅ Notarization completed'"
+echo ""
+echo "For more details, see NOTARIZATION_SETUP.md"

--- a/test-certificate-access.sh
+++ b/test-certificate-access.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Pulse24Sync - Certificate Access Test
+# This script tests if the self-hosted runner can access the Developer ID certificate
+
+echo "========================================"
+echo "Pulse24Sync - Certificate Access Test"
+echo "========================================"
+echo ""
+
+echo "🔍 Testing certificate access..."
+
+# Check if certificate is available
+IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1)
+
+if [ -z "$IDENTITY" ]; then
+    echo "❌ No Developer ID Application certificate found"
+    echo ""
+    echo "Troubleshooting:"
+    echo "1. Check if certificate is installed: security find-identity -v -p codesigning"
+    echo "2. Check keychain access: security list-keychains"
+    echo "3. Install certificate for the runner user if needed"
+    exit 1
+else
+    echo "✅ Certificate found: $IDENTITY"
+fi
+
+# Extract the identity name for testing
+IDENTITY_NAME=$(echo "$IDENTITY" | sed -n 's/.*"\(.*\)"/\1/p')
+
+echo ""
+echo "🔏 Testing code signing..."
+
+# Create a test file
+echo "test" > test.txt
+
+# Test code signing
+codesign --sign "$IDENTITY_NAME" test.txt
+
+if [ $? -eq 0 ]; then
+    echo "✅ Code signing test passed"
+
+    # Verify the signature
+    echo "🔍 Verifying signature..."
+    codesign --verify test.txt
+
+    if [ $? -eq 0 ]; then
+        echo "✅ Signature verification passed"
+    else
+        echo "⚠️  Signature verification failed"
+    fi
+
+    # Clean up
+    rm test.txt
+else
+    echo "❌ Code signing test failed"
+    rm test.txt
+    exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "Certificate Access Test: PASSED ✅"
+echo "========================================"
+echo ""
+echo "Your self-hosted runner can access the Developer ID certificate"
+echo "and perform code signing operations."
+echo ""
+echo "Next step: Set up GitHub secrets for notarization"

--- a/test-notarization.sh
+++ b/test-notarization.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Pulse24Sync - Notarization Credentials Test
+# This script tests if the notarization credentials work
+
+echo "========================================"
+echo "Pulse24Sync - Notarization Credentials Test"
+echo "========================================"
+echo ""
+
+echo "🔍 Testing notarization credentials..."
+
+# Check if required variables are set
+if [ -z "$APPLE_ID" ] || [ -z "$NOTARIZATION_PASSWORD" ] || [ -z "$DEVELOPMENT_TEAM" ]; then
+    echo "❌ Missing required environment variables"
+    echo ""
+    echo "Required variables:"
+    echo "  APPLE_ID: $APPLE_ID"
+    echo "  NOTARIZATION_PASSWORD: [set/not set]"
+    echo "  DEVELOPMENT_TEAM: $DEVELOPMENT_TEAM"
+    echo ""
+    echo "To set these variables:"
+    echo "1. Add them as GitHub secrets in your repository"
+    echo "2. Or set them locally:"
+    echo "   export APPLE_ID='your-apple-id@example.com'"
+    echo "   export NOTARIZATION_PASSWORD='your-app-specific-password'"
+    echo "   export DEVELOPMENT_TEAM='5HR8E5CWR7'"
+    echo ""
+    echo "Then run this script again."
+    exit 1
+fi
+
+echo "✅ Notarization credentials available"
+echo "  APPLE_ID: $APPLE_ID"
+echo "  DEVELOPMENT_TEAM: $DEVELOPMENT_TEAM"
+echo "  NOTARIZATION_PASSWORD: [set]"
+
+echo ""
+echo "🚀 Testing notarytool access..."
+
+# Test notarytool access
+xcrun notarytool info --apple-id "$APPLE_ID" --password "$NOTARIZATION_PASSWORD" --team-id "$DEVELOPMENT_TEAM"
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Notarization credentials work"
+    echo ""
+    echo "========================================"
+    echo "Notarization Credentials Test: PASSED ✅"
+    echo "========================================"
+    echo ""
+    echo "Your notarization credentials are working correctly."
+    echo "The GitHub Actions workflow should be able to notarize your plugins."
+    echo ""
+    echo "Next step: Push changes to trigger a workflow run"
+else
+    echo ""
+    echo "❌ Notarization credentials failed"
+    echo ""
+    echo "Troubleshooting:"
+    echo "1. Check your Apple ID is correct"
+    echo "2. Verify the app-specific password is valid"
+    echo "3. Ensure your Apple Developer account is active"
+    echo "4. Check that the team ID matches your Developer account"
+    echo ""
+    echo "To generate a new app-specific password:"
+    echo "1. Go to https://appleid.apple.com/"
+    echo "2. Sign in with your Apple ID"
+    echo "3. Click 'Sign-in and Security' → 'App-Specific Passwords'"
+    echo "4. Generate a new password named 'Pulse24Sync Notarization'"
+    exit 1
+fi


### PR DESCRIPTION
## 🎯 Problem Solved

This PR fixes the "Apple could not verify 'Pulse24Sync.component' is free of malware" warning by adding notarization to the GitHub Actions workflow.

### Root Cause
The plugin was code-signed with a Developer ID certificate but not notarized. macOS requires Developer ID applications to be notarized by Apple before they can run without triggering security warnings.

## ✅ Changes Made

### 1. Enhanced GitHub Actions Workflow
- **Added notarization step** after code signing in `.github/workflows/build.yml`
- **Added environment variables** for notarization credentials
- **Automatic notarization** of all plugin formats (VST3, AU, Standalone)
- **Verification and stapling** of notarization tickets

### 2. Comprehensive Documentation
- **`NOTARIZATION_SETUP.md`** - Complete guide for setting up notarization
- **`SELF_HOSTED_RUNNER_SETUP.md`** - Specific guide for self-hosted runners
- **`get-signing-info.sh`** - Helper script to extract signing information
- **Updated `README.md`** with links to all documentation

### 3. Testing Tools
- **`test-certificate-access.sh`** - Verifies certificate access on runners
- **`test-notarization.sh`** - Tests notarization credentials

## 🔑 Required Setup

To enable notarization, add these GitHub secrets to your repository:

1. **`CODE_SIGN_IDENTITY`**: `Developer ID Application: Eric Dahl (5HR8E5CWR7)`
2. **`DEVELOPMENT_TEAM`**: `5HR8E5CWR7`
3. **`APPLE_ID`**: Your Apple ID email address
4. **`NOTARIZATION_PASSWORD`**: App-specific password from https://appleid.apple.com/

## 🚀 Expected Results

After merging this PR and setting up the secrets:
- ✅ No more "Apple could not verify is free of malware" warnings
- ✅ Plugins install and run without security prompts
- ✅ Professional distribution-ready builds
- ✅ Users can download and use plugins without issues

## 🔍 Testing

The workflow will show success messages like:
```
✅ Notarization completed for Pulse24Sync.component
✅ Successfully stapled notarization to Pulse24Sync.component
✅ Notarization verification passed for Pulse24Sync.component
```

## 📋 Files Changed

- `.github/workflows/build.yml` - Added notarization step
- `NOTARIZATION_SETUP.md` - New notarization guide
- `SELF_HOSTED_RUNNER_SETUP.md` - New self-hosted runner guide
- `get-signing-info.sh` - New helper script
- `test-certificate-access.sh` - New test script
- `test-notarization.sh` - New test script
- `README.md` - Added documentation links

## 🛠️ Self-Hosted Runners

This PR works with both GitHub-hosted and self-hosted runners. GitHub secrets are automatically available to self-hosted runners.

## 📞 Next Steps

1. **Review and merge** this PR
2. **Set up GitHub secrets** as described above
3. **Push changes** to trigger a new workflow run
4. **Verify notarization** in the workflow logs

Your Pulse24Sync plugin will now be fully trusted by macOS and ready for professional distribution!